### PR TITLE
feat: add dataflow flex template harness

### DIFF
--- a/modules/harness-artifact-registry/main.tf
+++ b/modules/harness-artifact-registry/main.tf
@@ -1,0 +1,231 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+locals {
+  int_proj_required_roles = [
+    "roles/storage.admin",
+    "roles/storage.objectCreator",
+    "roles/browser",
+    "roles/artifactregistry.admin",
+    "roles/iam.serviceAccountCreator",
+    "roles/iam.serviceAccountDeleter",
+    "roles/cloudbuild.builds.editor",
+    "roles/serviceusage.serviceUsageAdmin"
+  ]
+
+  apis_to_enable = [
+    "cloudresourcemanager.googleapis.com",
+    "compute.googleapis.com",
+    "storage-api.googleapis.com",
+    "serviceusage.googleapis.com",
+    "iam.googleapis.com",
+    "cloudbilling.googleapis.com",
+    "artifactregistry.googleapis.com",
+    "cloudbuild.googleapis.com"
+  ]
+
+  project_name = var.project_name != "" ? var.project_name : "ext-harness-${random_id.project_id_suffix.hex}"
+  project_id   = module.external_flex_template_project.project_id
+
+  docker_repository_id  = "flex-templates"
+  docker_repository_url = "${var.location}-docker.pkg.dev/${local.project_id}/${google_artifact_registry_repository.flex_templates.name}"
+
+  python_repository_id  = "python-modules"
+  python_repository_url = "${var.location}-python.pkg.dev/${local.project_id}/${google_artifact_registry_repository.python_modules.name}"
+  pip_index_url         = "https://${var.location}-python.pkg.dev/${local.project_id}/${local.python_repository_id}/simple/"
+
+}
+
+resource "random_id" "project_id_suffix" {
+  byte_length = 3
+}
+
+module "external_flex_template_project" {
+  source  = "terraform-google-modules/project-factory/google"
+  version = "14.0"
+
+  name                    = local.project_name
+  random_project_id       = "true"
+  org_id                  = var.org_id
+  folder_id               = var.folder_id
+  billing_account         = var.billing_account
+  default_service_account = "deprivilege"
+
+  activate_apis = [
+    "cloudresourcemanager.googleapis.com",
+    "storage-api.googleapis.com",
+    "serviceusage.googleapis.com",
+    "iam.googleapis.com",
+    "cloudbilling.googleapis.com",
+    "artifactregistry.googleapis.com",
+    "cloudbuild.googleapis.com",
+    "compute.googleapis.com"
+  ]
+}
+
+# The name of this bucket is the name of the bucket that
+# Cloud Build creates to host the source code if one is
+# not provided with the flag `--gcs-source-staging-dir`.
+# Creating the bucket beforehand is necessary because it
+# is not possible to pass a `--gcs-source-staging-dir`
+# flag to the gcloud dataflow flex-template build command
+# used in the cloudbuild.yaml file.
+resource "google_storage_bucket" "cloudbuild_bucket" {
+  name     = "${local.project_id}_cloudbuild"
+  location = var.location
+  project  = local.project_id
+
+  force_destroy               = true
+  uniform_bucket_level_access = true
+
+  depends_on = [
+    module.external_flex_template_project
+  ]
+}
+
+resource "google_project_iam_member" "int_permission_artifact_registry_test" {
+  for_each = toset(local.int_proj_required_roles)
+
+  project = module.external_flex_template_project.project_id
+  role    = each.value
+  member  = "serviceAccount:${var.service_account_email}"
+}
+
+resource "google_project_service" "apis_to_enable" {
+  for_each = toset(local.apis_to_enable)
+
+  project            = local.project_id
+  service            = each.key
+  disable_on_destroy = false
+
+  depends_on = [
+    google_project_iam_member.int_permission_artifact_registry_test
+  ]
+}
+
+resource "google_project_service_identity" "cloudbuild_sa" {
+  provider = google-beta
+
+  project = local.project_id
+  service = "cloudbuild.googleapis.com"
+
+  depends_on = [
+    google_project_service.apis_to_enable
+  ]
+}
+
+resource "google_project_iam_member" "cloud_build_builder" {
+  project = local.project_id
+  role    = "roles/cloudbuild.builds.builder"
+  member  = "serviceAccount:${google_project_service_identity.cloudbuild_sa.email}"
+}
+
+resource "google_artifact_registry_repository" "flex_templates" {
+  provider = google-beta
+
+  project       = local.project_id
+  location      = var.location
+  repository_id = local.docker_repository_id
+  description   = "DataFlow Flex Templates"
+  format        = "DOCKER"
+
+  depends_on = [
+    google_project_service.apis_to_enable
+  ]
+}
+
+resource "google_artifact_registry_repository_iam_member" "docker_writer" {
+  provider = google-beta
+
+  project    = local.project_id
+  location   = var.location
+  repository = local.docker_repository_id
+  role       = "roles/artifactregistry.writer"
+  member     = "serviceAccount:${google_project_service_identity.cloudbuild_sa.email}"
+
+  depends_on = [
+    google_artifact_registry_repository.flex_templates
+  ]
+}
+
+resource "google_artifact_registry_repository" "python_modules" {
+  provider = google-beta
+
+  project       = local.project_id
+  location      = var.location
+  repository_id = local.python_repository_id
+  description   = "Repository for Python modules for Dataflow flex templates"
+  format        = "PYTHON"
+
+  depends_on = [
+    google_project_service.apis_to_enable
+  ]
+}
+
+resource "google_artifact_registry_repository_iam_member" "python_writer" {
+  provider = google-beta
+
+  project    = local.project_id
+  location   = var.location
+  repository = local.python_repository_id
+  role       = "roles/artifactregistry.writer"
+  member     = "serviceAccount:${google_project_service_identity.cloudbuild_sa.email}"
+
+  depends_on = [
+    google_artifact_registry_repository.python_modules
+  ]
+}
+
+resource "random_id" "suffix" {
+  byte_length = 2
+}
+
+resource "google_storage_bucket" "templates_bucket" {
+  name     = "bkt-${local.project_id}-tpl-${random_id.suffix.hex}"
+  location = var.location
+  project  = local.project_id
+
+  force_destroy               = true
+  uniform_bucket_level_access = true
+
+  depends_on = [
+    google_project_service.apis_to_enable
+  ]
+}
+
+// It's necessary to use the wait_60_seconds to guarantee the infrastructure is fully built before removing the owner role.
+resource "time_sleep" "wait_60_seconds" {
+  create_duration = "60s"
+
+  depends_on = [
+    google_storage_bucket.templates_bucket,
+    google_artifact_registry_repository_iam_member.python_writer,
+    google_artifact_registry_repository_iam_member.docker_writer,
+    google_project_iam_member.cloud_build_builder
+  ]
+}
+
+resource "google_project_iam_binding" "remove_owner_role_from_template" {
+  project = local.project_id
+  role    = "roles/owner"
+  members = []
+
+  depends_on = [
+    time_sleep.wait_60_seconds
+  ]
+}
+

--- a/modules/harness-artifact-registry/outputs.tf
+++ b/modules/harness-artifact-registry/outputs.tf
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "project_id" {
+  description = "The project ID of the template project."
+  value       = module.external_flex_template_project.project_id
+
+  depends_on = [
+    module.external_flex_template_project
+  ]
+}
+
+output "sdx_project_number" {
+  description = "The Project Number to configure Secure data exchange with egress rule for the dataflow templates."
+  value       = module.external_flex_template_project.project_number
+
+  depends_on = [
+    module.external_flex_template_project
+  ]
+}
+
+output "flex_template_bucket_name" {
+  description = "The name of the bucket created to store the flex template."
+  value       = google_storage_bucket.templates_bucket.name
+}
+
+output "flex_template_repository_name" {
+  description = "The name of the flex template artifact registry repository."
+  value       = google_artifact_registry_repository.flex_templates.name
+}
+
+output "docker_flex_template_repository_url" {
+  description = "URL of the docker flex template artifact registry repository."
+  value       = local.docker_repository_url
+}
+
+output "docker_flex_template_repository_id" {
+  description = "ID of the docker flex template artifact registry repository."
+  value       = local.docker_repository_id
+}
+
+output "python_flex_template_repository_url" {
+  description = "URL of the docker flex template artifact registry repository."
+  value       = local.python_repository_url
+}
+
+output "python_flex_template_repository_id" {
+  description = "ID of the docker flex template artifact registry repository."
+  value       = local.python_repository_id
+}
+
+output "cloudbuild_bucket_name" {
+  description = "The name of the Google Storage Bucket used to save temporary files in Cloud Build builds."
+  value       = google_storage_bucket.cloudbuild_bucket.name
+}
+
+output "pip_index_url" {
+  description = "The URL of the Python Package Index repository to be used to load the Python third-party packages."
+  value       = local.pip_index_url
+}

--- a/modules/harness-artifact-registry/variables.tf
+++ b/modules/harness-artifact-registry/variables.tf
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "org_id" {
+  description = "The numeric organization id."
+  type        = string
+}
+
+variable "folder_id" {
+  description = "The folder to deploy in."
+  type        = string
+}
+
+variable "project_name" {
+  description = "Custom project name for the template project."
+  type        = string
+  default     = ""
+}
+
+variable "billing_account" {
+  description = "The billing account id associated with the project, e.g. XXXXXX-YYYYYY-ZZZZZZ."
+  type        = string
+}
+
+variable "location" {
+  description = "Artifact Registry location."
+  type        = string
+}
+
+variable "service_account_email" {
+  description = "Terraform service account email"
+  type        = string
+}

--- a/modules/harness-artifact-registry/versions.tf
+++ b/modules/harness-artifact-registry/versions.tf
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_version = ">= 0.13"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 4.61.0, < 5.0"
+    }
+
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "< 5.0"
+    }
+
+    random = {
+      source  = "hashicorp/random"
+      version = "3.5.1"
+    }
+
+    time = {
+      source  = "hashicorp/time"
+      version = "0.9.1"
+    }
+  }
+}

--- a/modules/harness-build-flex-template/main.tf
+++ b/modules/harness-build-flex-template/main.tf
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+locals {
+  image_name              = "pubsub-dataflow-bigquery-flex"
+  flex_template_image_tag = "${var.docker_repository_url}/samples/${local.image_name}:latest"
+  template_gs_path        = "gs://${var.flex_template_bucket_name}/flex-template-samples/${local.image_name}.json"
+}
+
+resource "null_resource" "python_pubsub_dataflow_bq_flex_template" {
+
+  triggers = {
+    project_id                = var.project_id
+    terraform_service_account = var.service_account_email
+    template_image_tag        = local.flex_template_image_tag
+    template_gs_path          = local.template_gs_path
+  }
+
+  provisioner "local-exec" {
+    when    = create
+    command = <<EOF
+      gcloud builds submit \
+       --project=${var.project_id} \
+       --gcs-source-staging-dir="gs://${var.cloudbuild_bucket_name}/source" \
+       --config ${path.module}/pubsub_dataflow_bigquery/cloudbuild.yaml \
+       --impersonate-service-account=${var.service_account_email} \
+       --substitutions="_PROJECT=${var.project_id},_FLEX_TEMPLATE_IMAGE_TAG=${local.flex_template_image_tag},_PIP_INDEX_URL=${var.pip_index_url},_TEMPLATE_GS_PATH=${local.template_gs_path}" \
+       ${path.module}/pubsub_dataflow_bigquery
+EOF
+
+  }
+}

--- a/modules/harness-build-flex-template/outputs.tf
+++ b/modules/harness-build-flex-template/outputs.tf
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "template_gs_path" {
+  description = "The path to the Dataflow Flex template save in the Cloud Storage bucket."
+  value       = local.template_gs_path
+
+  depends_on = [
+    null_resource.python_pubsub_dataflow_bq_flex_template
+  ]
+}

--- a/modules/harness-build-flex-template/pubsub_dataflow_bigquery/Dockerfile
+++ b/modules/harness-build-flex-template/pubsub_dataflow_bigquery/Dockerfile
@@ -1,0 +1,37 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/dataflow-templates-base/python38-template-launcher-base
+
+ARG ARG_PIP_INDEX_URL=https://us-east4-python.pkg.dev/project-id/python-modules/simple/
+
+ENV FLEX_TEMPLATE_PYTHON_REQUIREMENTS_FILE="/template/requirements.txt"
+ENV FLEX_TEMPLATE_PYTHON_PY_FILE="/template/pubsub_transform_bigquery.py"
+
+COPY . /template
+
+# We could get rid of installing libffi-dev and git, or we could leave them.
+RUN apt-get update \
+    && apt-get install -y libffi-dev git \
+    && rm -rf /var/lib/apt/lists/* \
+    # Upgrade pip and install the requirements.
+    && pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir twine keyrings.google-artifactregistry-auth \
+    && pip install --no-cache-dir -r $FLEX_TEMPLATE_PYTHON_REQUIREMENTS_FILE \
+    # Download the requirements to speed up launching the Dataflow job.
+    && pip download --no-cache-dir --dest /tmp/dataflow-requirements-cache -r $FLEX_TEMPLATE_PYTHON_REQUIREMENTS_FILE
+
+# Since we already downloaded all the dependencies, there's no need to rebuild everything.
+ENV PIP_NO_DEPS=True
+ENV PIP_INDEX_URL=$ARG_PIP_INDEX_URL

--- a/modules/harness-build-flex-template/pubsub_dataflow_bigquery/README.md
+++ b/modules/harness-build-flex-template/pubsub_dataflow_bigquery/README.md
@@ -1,0 +1,45 @@
+# Pub/Sub to BigQuery transformation flex template (Streaming)
+
+This template is base on the public [Streaming Wordcount](https://github.com/apache/beam/blob/master/sdks/python/apache_beam/examples/streaming_wordcount.py) example, adding a transformation that can be applied to the data been processed.
+
+## Build the flex template
+
+Set the following environment variables based in the resources create in the infrastructure step:
+
+```shell
+export LOCATION=<REPOSITORY-LOCATION>
+export PROJECT=<YOUR-PROJECT>
+export BUCKET=<YOUR-FLEX-TEMPLATE-BUCKET>
+export TEMPLATE_IMAGE_TAG="$LOCATION-docker.pkg.dev/$PROJECT/flex-templates/samples/pubsub-dataflow-bigquery-flex:latest"
+export TEMPLATE_GS_PATH="gs://$BUCKET/flex-template-samples/pubsub-dataflow-bigquery-flex.json"
+export PIP_INDEX_URL="https://$LOCATION-python.pkg.dev/$PROJECT/python-modules/simple/"
+```
+
+### Create the template with Cloud Build
+
+```shell
+# build the flex template
+
+gcloud beta builds submit \
+ --project=$PROJECT \
+ --config ./cloudbuild.yaml . \
+ --substitutions="_PROJECT=$PROJECT,_FLEX_TEMPLATE_IMAGE_TAG=$TEMPLATE_IMAGE_TAG,_TEMPLATE_GS_PATH=$TEMPLATE_GS_PATH,_PIP_INDEX_URL=$PIP_INDEX_URL"
+ ```
+
+### Manually Create the template
+
+Build the Flex Image:
+
+```shell
+
+docker build \
+--tag="$TEMPLATE_IMAGE_TAG"
+--build-arg=ARG_PIP_INDEX_URL="$PIP_INDEX_URL" \
+.
+
+gcloud dataflow flex-template build "$TEMPLATE_GS_PATH" \
+  --image "$TEMPLATE_IMAGE_TAG" \
+  --sdk-language "PYTHON" \
+  --project=$PROJECT \
+  --metadata-file "./metadata.json"
+```

--- a/modules/harness-build-flex-template/pubsub_dataflow_bigquery/cloudbuild.yaml
+++ b/modules/harness-build-flex-template/pubsub_dataflow_bigquery/cloudbuild.yaml
@@ -1,0 +1,42 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args: [
+    'build',
+    '--tag=${_FLEX_TEMPLATE_IMAGE_TAG}',
+    '--build-arg=ARG_PIP_INDEX_URL=${_PIP_INDEX_URL}',
+    '.'
+    ]
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['push', '${_FLEX_TEMPLATE_IMAGE_TAG}']
+- name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+  entrypoint: 'gcloud'
+  args: [
+    'dataflow', 'flex-template', 'build', '${_TEMPLATE_GS_PATH}',
+    '--image', '${_FLEX_TEMPLATE_IMAGE_TAG}',
+    '--sdk-language', 'PYTHON',
+    '--project', '${_PROJECT}',
+    '--metadata-file', './metadata.json',
+    ]
+images: ['${_FLEX_TEMPLATE_IMAGE_TAG}']
+substitutions:
+  _PROJECT: 'PROJECT'
+  _FLEX_TEMPLATE_IMAGE_TAG: 'us-east4-docker.pkg.dev/PROJECT_ID/flex-templates/samples/pubsub-dataflow-bigquery-flex:latest' # default value
+  _TEMPLATE_GS_PATH: 'gs://BUCKET/flex-template-samples/pubsub-dataflow-bigquery-flex.json'
+  _PIP_INDEX_URL: 'https://us-east4-python.pkg.dev/PROJECT_ID/python-modules/simple/'
+options:
+  logging: CLOUD_LOGGING_ONLY
+timeout: 900s

--- a/modules/harness-build-flex-template/pubsub_dataflow_bigquery/metadata.json
+++ b/modules/harness-build-flex-template/pubsub_dataflow_bigquery/metadata.json
@@ -1,0 +1,40 @@
+{
+  "name": "Streaming beam Python Pub/Sub to BigQuery transformation flex template",
+  "description": "Streaming beam Python Pub/Sub to BigQuery transformation flex template.",
+  "parameters": [
+    {
+      "name": "input_subscription",
+      "label": "Input PubSub subscription.",
+      "helpText": "Name of the input PubSub subscription to consume from. Format is 'projects/<PROJECT>/subscriptions/<SUBSCRIPTION>'. If provided, input_topic must be empty.",
+      "isOptional": true,
+      "regexes": [
+        "projects/[^/]+/subscriptions/[a-zA-Z][-_.~+%a-zA-Z0-9]{2,}"
+      ]
+    },
+    {
+      "name": "input_topic",
+      "label": "Input PubSub Topic.",
+      "helpText": "Name of the input PubSub Topic to consume from. Format is 'projects/<PROJECT>/topics/<TOPIC>'. If provided, input_subscription must be empty. A temporary subscription will be created from the specified topic.",
+      "isOptional": true,
+      "regexes": [
+        "projects/[^/]+/topics/[a-zA-Z][-_.~+%a-zA-Z0-9]{2,}"
+      ]
+    },
+    {
+      "name": "window_interval_sec",
+      "label": "Window interval in seconds.",
+      "helpText": "Window interval in seconds for grouping incoming messages.",
+      "isOptional": true
+    },
+    {
+      "name": "bq_schema",
+      "label": "BigQuery table schema.",
+      "helpText": "Output BigQuery table schema specified as string with format: FIELD_1:STRING,FIELD_2:STRING,..."
+    },
+    {
+      "name": "output_table",
+      "label": "BigQuery output table name.",
+      "helpText": "Output BigQuery table for results specified as: PROJECT:DATASET.TABLE or DATASET.TABLE."
+    }
+  ]
+}

--- a/modules/harness-build-flex-template/pubsub_dataflow_bigquery/pubsub_transform_bigquery.py
+++ b/modules/harness-build-flex-template/pubsub_dataflow_bigquery/pubsub_transform_bigquery.py
@@ -1,0 +1,158 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import argparse
+import json
+import logging
+
+import apache_beam as beam
+import apache_beam.transforms.window as window
+from apache_beam.options.pipeline_options import PipelineOptions
+
+
+def run(argv=None, save_main_session=True):
+    """Build and run the pipeline."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--output_table',
+        required=True,
+        help=(
+            'Output BigQuery table for results specified as: '
+            'PROJECT:DATASET.TABLE or DATASET.TABLE.'
+        )
+    )
+    parser.add_argument(
+        '--bq_schema',
+        required=True,
+        help=(
+            'Output BigQuery table schema specified as string with format: '
+            'FIELD_1:STRING,FIELD_2:STRING,...'
+        )
+    )
+    parser.add_argument(
+        "--window_interval_sec",
+        default=30,
+        type=int,
+        help=(
+            'Window interval in seconds for grouping incoming messages.'
+        )
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        '--input_topic',
+        help=(
+            'Input PubSub topic of the form '
+            '"projects/<PROJECT>/topics/<TOPIC>".'
+            'A temporary subscription will be created from '
+            'the specified topic.'
+        )
+    )
+    group.add_argument(
+        '--input_subscription',
+        help=(
+            'Input PubSub subscription of the form '
+            '"projects/<PROJECT>/subscriptions/<SUBSCRIPTION>."'
+        )
+    )
+    known_args, pipeline_args = parser.parse_known_args(argv)
+
+    options = PipelineOptions(
+        pipeline_args,
+        save_main_session=True,
+        streaming=True
+    )
+
+    with beam.Pipeline(options=options) as p:
+
+        # Read from PubSub into a PCollection.
+        # If input_subscription provided, it will be used.
+        # If input_subscription not provided, input_topic will be used.
+        # If input_topic provided, a temporary subscription will be created
+        # from the specified topic.
+        if known_args.input_subscription:
+            messages = (
+                p
+                | 'Read from Pub/Sub' >>
+                beam.io.ReadFromPubSub(
+                    subscription=known_args.input_subscription
+                ).with_output_types(bytes)
+                | 'UTF-8 bytes to string' >>
+                beam.Map(lambda msg: msg.decode("utf-8"))
+                | 'Parse JSON payload' >>
+                beam.Map(json.loads)
+                | 'Flatten lists' >>
+                beam.FlatMap(normalize_data)
+                | 'Apply window' >> beam.WindowInto(
+                    window.FixedWindows(known_args.window_interval_sec, 0)
+                )
+            )
+        else:
+            messages = (
+                p
+                | 'Read from Pub/Sub' >>
+                beam.io.ReadFromPubSub(
+                    topic=known_args.input_topic
+                ).with_output_types(bytes)
+                | 'UTF-8 bytes to string' >>
+                beam.Map(lambda msg: msg.decode("utf-8"))
+                | 'Parse JSON payload' >>
+                beam.Map(json.loads)
+                | 'Flatten lists' >>
+                beam.FlatMap(normalize_data)
+                | 'Apply window' >> beam.WindowInto(
+                    window.FixedWindows(known_args.window_interval_sec, 0)
+                )
+            )
+
+        transformed_messages = (
+            messages
+            | 'Data transformation' >> beam.Map(transform_data)
+            )
+
+        # Write to BigQuery.
+        transformed_messages | 'Write to BQ' >> beam.io.WriteToBigQuery(
+            known_args.output_table,
+            schema=known_args.bq_schema,
+            create_disposition=beam.io.BigQueryDisposition.CREATE_IF_NEEDED
+        )
+
+
+def normalize_data(data):
+    """
+    The template reads a json from PubSub that can be a single object
+    or a List of objects. This function is used by a FlatMap transformation
+    to normalize the input in to individual objects.
+    See:
+     - https://beam.apache.org/documentation/transforms/python/elementwise/flatmap/
+    """  # noqa
+    if isinstance(data, list):
+        return data
+    return [data]
+
+
+def transform_data(message):
+    """
+    The "message" input is a json object representing the data
+    read from the Pub/Sub subscription or topic.
+    Replace this code example with your own data transformation.
+    """
+    message['Issue_Date'] = message['Issue_Date'].replace("/", "-")
+    return message
+
+
+if __name__ == '__main__':
+    logging.getLogger().setLevel(logging.INFO)
+    run()

--- a/modules/harness-build-flex-template/pubsub_dataflow_bigquery/requirements.txt
+++ b/modules/harness-build-flex-template/pubsub_dataflow_bigquery/requirements.txt
@@ -1,0 +1,1 @@
+apache-beam==2.49.0

--- a/modules/harness-build-flex-template/variables.tf
+++ b/modules/harness-build-flex-template/variables.tf
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  description = "The ID of the project in which to provision resources."
+  type        = string
+}
+
+variable "flex_template_bucket_name" {
+  description = "The name of the Google Storage Bucket used to save the Dataflow flex template created."
+  type        = string
+}
+
+variable "cloudbuild_bucket_name" {
+  description = "The name of the Google Storage Bucket used to save temporary files in Cloud Build builds."
+  type        = string
+}
+
+variable "docker_repository_url" {
+  description = "URL of the docker flex template artifact registry repository."
+  type        = string
+}
+
+variable "service_account_email" {
+  description = "Terraform service account email"
+  type        = string
+}
+
+variable "pip_index_url" {
+  description = "The URL of the Python Package Index repository to be used to load the Python third-party packages."
+  type        = string
+}

--- a/modules/harness-build-flex-template/versions.tf
+++ b/modules/harness-build-flex-template/versions.tf
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_version = ">= 0.13"
+
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "3.2.1"
+    }
+  }
+}

--- a/modules/harness-upload-python-modules/files/README.md
+++ b/modules/harness-upload-python-modules/files/README.md
@@ -1,0 +1,13 @@
+# Populate the Python artifact registry
+
+Upload to the Python artifact registry the modules that will be used when the Python Dataflow jobs is staged.
+
+```shell
+export LOCATION=<REPOSITORY-LOCATION>
+export PROJECT=<YOUR-PROJECT>
+
+gcloud beta builds submit \
+ --project=$PROJECT \
+ --config ./cloudbuild.yaml . \
+--substitutions="_REPOSITORY_ID=python-modules,_DEFAULT_REGION=$LOCATION"
+ ```

--- a/modules/harness-upload-python-modules/files/cloudbuild.yaml
+++ b/modules/harness-upload-python-modules/files/cloudbuild.yaml
@@ -1,0 +1,27 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+- name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+  args: ['/bin/bash', '-c', './py-modules.sh ${_APACHE_BEAM_VERSION} https://${_DEFAULT_REGION}-python.pkg.dev/$PROJECT_ID/${_REPOSITORY_ID}/ ${_PYTHON_VERSION} ${_IMPLEMENTATION} ${_APPLICATION_BINARY_INTERFACE} ${_PLATFORM}']
+substitutions:
+  _APACHE_BEAM_VERSION: '2.49.0' # default value
+  _DEFAULT_REGION: 'us-east4' # default value
+  _REPOSITORY_ID: 'python-modules' # default value
+  _PYTHON_VERSION: '38' # default value
+  _IMPLEMENTATION: 'cp' # default value
+  _APPLICATION_BINARY_INTERFACE: 'cp38' # default value
+  _PLATFORM: 'manylinux_2_17_x86_64' # default value
+options:
+  logging: CLOUD_LOGGING_ONLY

--- a/modules/harness-upload-python-modules/files/py-modules.sh
+++ b/modules/harness-upload-python-modules/files/py-modules.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+apache_beam_version=$1
+python_repository_url=$2
+python_version=$3
+implementation=$4
+application_binary_interface=$5
+platform=$6
+
+if [ "$#" -lt 6 ]; then
+    >&2 echo "Not all expected arguments set."
+    echo "apache_beam_version=${apache_beam_version}"
+    echo "python_repository_url=${python_repository_url}"
+    echo "python_version=${python_version}"
+    echo "implementation=${implementation}"
+    echo "application_binary_interface=${application_binary_interface}"
+    echo "platform=${platform}"
+    exit 1
+fi
+
+# Install dependencies
+apt install unzip
+pip3 install --no-cache-dir twine keyrings.google-artifactregistry-auth
+
+# Create temp dir for the Python modules
+mkdir -p artifact_registry_rep
+
+# Download Python modules
+pip3 download --dest=./artifact_registry_rep -r ./requirements.txt --no-deps --no-binary=:all:
+pip3 download --dest=./artifact_registry_rep apache-beam=="${apache_beam_version}" --no-deps --no-binary=:all:
+pip3 download --dest=./artifact_registry_rep apache-beam=="${apache_beam_version}" --no-deps --only-binary=:all: --python-version="${python_version}" --implementation="${implementation}" --abi="${application_binary_interface}" --platform="${platform}"
+
+# This 'unzip' and 'tar -czf' steps are necessary because Artifact Registry does not support .zip files, only .tar.gz files
+# and Apache Beam sources are released as .zip files.
+unzip -q "./artifact_registry_rep/apache-beam-${apache_beam_version}.zip"  -d ./artifact_registry_rep
+tar -C ./artifact_registry_rep/  -czf "./artifact_registry_rep/apache-beam-${apache_beam_version}.tar.gz" "apache-beam-${apache_beam_version}"
+
+# Remove temp apache beam dir and zip file
+rm -rf "./artifact_registry_rep/apache-beam-${apache_beam_version}.zip" "./artifact_registry_rep/apache-beam-${apache_beam_version}"
+
+# This step cannot be a direct upload of the whole ./artifact_registry_rep/ because Artifact Registry does not support the
+# twine command line option --skip-existing to continue uploading files if one already exists.
+# If a file already exists the upload fails, so we need the '|| true' to continue with the upload.
+for python_module in "./artifact_registry_rep"/*
+do
+  twine upload --repository-url "${python_repository_url}" "$python_module" || true
+done

--- a/modules/harness-upload-python-modules/files/requirements.txt
+++ b/modules/harness-upload-python-modules/files/requirements.txt
@@ -1,0 +1,1 @@
+apache-beam==2.49.0

--- a/modules/harness-upload-python-modules/main.tf
+++ b/modules/harness-upload-python-modules/main.tf
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+resource "null_resource" "upload_modules" {
+
+  triggers = {
+    project_id                = var.project_id
+    repository_id             = var.python_repository_id
+    location                  = var.location
+    terraform_service_account = var.service_account_email
+  }
+
+  provisioner "local-exec" {
+    when    = create
+    command = <<EOF
+     gcloud builds submit \
+     --project=${var.project_id} \
+     --gcs-source-staging-dir="gs://${var.cloudbuild_bucket_name}/source" \
+     --config ${path.module}/files/cloudbuild.yaml \
+     --impersonate-service-account=${var.service_account_email} \
+     --substitutions=_REPOSITORY_ID=${var.python_repository_id},_DEFAULT_REGION=${var.location} \
+     ${path.module}/files
+EOF
+
+  }
+}

--- a/modules/harness-upload-python-modules/variables.tf
+++ b/modules/harness-upload-python-modules/variables.tf
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  description = "The ID of the project in which to provision resources."
+  type        = string
+}
+
+variable "python_repository_id" {
+  description = "ID of the Python repository."
+  type        = string
+}
+
+variable "location" {
+  description = "The location of Artifact registry. Run `gcloud artifacts locations list` to list available locations."
+  type        = string
+}
+
+variable "cloudbuild_bucket_name" {
+  description = "The name of the Google Storage Bucket used to save temporary files in Cloud Build builds."
+  type        = string
+}
+
+variable "service_account_email" {
+  description = "Terraform service account email"
+  type        = string
+}

--- a/modules/harness-upload-python-modules/versions.tf
+++ b/modules/harness-upload-python-modules/versions.tf
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_version = ">= 0.13"
+
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "3.2.1"
+    }
+  }
+}


### PR DESCRIPTION
This PR adds modules that:
- Creates a project to host the Artifact Registry
- Creates a docker repository
- Creates a Python repository
- Upload Apache Beam python module to the Python repository
- Build a dataflow flex template