### PR TITLE
docs: use confidential computing on dataflow example

### DIFF
--- a/docs/deploying_dataflow_jobs.md
+++ b/docs/deploying_dataflow_jobs.md
@@ -81,6 +81,11 @@ Make sure you have your subnetwork configured as the [Subnetwork section](#subne
 
 Enabling Streaming Engine is important to ensure all the performance benefits of the infrastructure. You can learn more about it in the [documentation](https://cloud.google.com/dataflow/docs/guides/deploying-a-pipeline#streaming-engine).
 
+## Enable Confidential Computing
+
+Enabling Confidential Computing helps to ensure the data can't be read or modified while in use. For more information check [Confidential Computing concepts](https://cloud.google.com/confidential-computing/confidential-vm/docs/confidential-vm-overview).
+You can access the list of confidential computing supported machines [here](https://cloud.google.com/confidential-computing/confidential-vm/docs/supported-configurations).
+
 ## Deploying Dataflow Flex Jobs
 
 We recommend the usage of [Flex Job Templates](https://cloud.google.com/dataflow/docs/guides/templates/using-flex-templates).

--- a/examples/standalone/workloads.tf
+++ b/examples/standalone/workloads.tf
@@ -983,8 +983,10 @@ resource "google_dataflow_flex_template_job" "dataflow_flex_template_job" {
   kms_key_name            = module.secured_data_warehouse_onprem_ingest.cmek_data_ingestion_crypto_key
   subnetwork              = module.harness_projects.data_ingestion_subnets_self_link
   ip_configuration        = "WORKER_IP_PRIVATE"
+  machine_type            = "n2d-standard-2" # For confidential computing supported machines list access: <https://cloud.google.com/confidential-computing/confidential-vm/docs/supported-configurations>
   additional_experiments = [
     "enable_kms_on_streaming_engine",
+    "enable_confidential_compute",
   ]
 
   parameters = {


### PR DESCRIPTION
This PR enables confidential computing to ensure the data can't be read or modified while in use.